### PR TITLE
Fixes for Julia v1.0 and v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
 #  - osx
 julia:
- - 0.6
+ - 0.7
+ . 1.0
  - nightly
 
 matrix:
@@ -35,4 +36,4 @@ git:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("CommunityDetection"); Pkg.test("CommunityDetection"; coverage=true)'
 after_success:
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("CommunityDetection")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'cd(using Pkg; Pkg.dir("CommunityDetection")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.6
-LightGraphs 0.9
+julia 0.7
+LightGraphs 1.1.0
 Clustering
+ArnoldiMethod


### PR DESCRIPTION
This makes this package run on Julia v1.0. 

**Note:** There are some minor functional differences:
1. I had to introduce a threshold for checking if a eigenvalue is < 0 in `community_detection_bethe`, as the eigenvalues computed with `ArnoldiMethod` only get very close to zero.
2. By switching to `ArnoldiMethod`, I had to remove the starting vector for the the Arnoldi Iteration in `nonbacktrack_embedding` as this is not a feature there. Because of this, the starting vector is chosen randomly and the test can fail with some small probability.

Other Stuff: 
- `community_detection_nback` has some problems if the graph is very sparse. I'm not yet sure if this is only a problem if the non-backtracking-matrix is the zero matrix, but it seems to be related to JuliaGraphs/LightGraphs.jl#1015 
- The interface currently allows for directed graphs. I don't know if community detection even makes sense in these cases, but right now this leads to some problems when the adjacency matrix becomes non-symmetric which leads to non-real eigenvalues.